### PR TITLE
Fix bug RT3696: do not re-arm the KeepAlive timer on remote packet reception

### DIFF
--- a/src/common/rohc_tunnel.c
+++ b/src/common/rohc_tunnel.c
@@ -622,16 +622,7 @@ void * iprohc_tunnel_run(void *arg)
 					}
 				}
 
-				/* re-arm keepalive timer */
-				if(!iprohc_session_update_keepalive(session,
-				                                    tunnel->params.keepalive_timeout))
-				{
-					tunnel_trace(session, LOG_ERR, "failed to update the keepalive "
-					             "timeout to %zu seconds",
-					             tunnel->params.keepalive_timeout);
-					session->status = IPROHC_SESSION_PENDING_DELETE;
-					goto close_pollfd;
-				}
+				/* Packet received from remote, reset missed keepalive */
 				session->keepalive_misses = 0;
 			}
 		}


### PR DESCRIPTION
If remote peer sends KeepAlive packets before local peer, local timer resets its keepalive timer without sending any KeepAlive to the other side.
If remote and local timers are well timed, remote peer will never get KeepAlive before expiration of its timer (and new KeepAlive emission), and remote peer will time out after 3 KeepAlive.

This fix is disabling the re-arm of the timer on KeepAlive reception:
- Both side will always send KeepAlive every 20s whatever the TCP channel activity
- Counter of missed KeepAlive is reset when host receives KeepAlive from remote
