### PR TITLE
Fix bug RT3696: filter incoming ROHC packet on our local IP address

### DIFF
--- a/src/common/session.c
+++ b/src/common/session.c
@@ -93,7 +93,7 @@ bool iprohc_session_new(struct iprohc_session *const session,
 	session->stop_ctrl = stop_ctrl;
 	session->handle_ctrl_opaque = handle_ctrl_opaque;
 	session->local_address = local_addr;
-	session->src_addr.s_addr = INADDR_ANY;
+	session->src_addr.s_addr = ntohl(local_addr.s_addr);
 	session->dst_addr = remote_addr.sin_addr;
 	session->status = IPROHC_SESSION_CONNECTING;
 	session->thread_tunnel = -1;


### PR DESCRIPTION
Local IP source is set at INADDR_ANY.

Thus, filtering of incoming packets is not effective and all incoming ROHC packets (from any interfaces)  is processed by the iprohc_client.

The fix is setting our local IP (the one used by the TCP channel) as our local address (used by the filtering mechanism).
