### PR TITLE
Fix/rt3634/memleak

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -352,6 +352,9 @@ int main(int argc, char *argv[])
 	 * Initialize client context
 	 */
 
+	/* Configure libgcrypt backend for use in multi-threaded environment */
+	gcry_control (GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
+
 	/* load certificates and key for TLS session */
 	gnutls_global_init();
 	gnutls_certificate_allocate_credentials(&(client.tls_cred));

--- a/src/common/rohc_tunnel.c
+++ b/src/common/rohc_tunnel.c
@@ -622,16 +622,7 @@ void * iprohc_tunnel_run(void *arg)
 					}
 				}
 
-				/* re-arm keepalive timer */
-				if(!iprohc_session_update_keepalive(session,
-				                                    tunnel->params.keepalive_timeout))
-				{
-					tunnel_trace(session, LOG_ERR, "failed to update the keepalive "
-					             "timeout to %zu seconds",
-					             tunnel->params.keepalive_timeout);
-					session->status = IPROHC_SESSION_PENDING_DELETE;
-					goto close_pollfd;
-				}
+				/* Packet received from remote, reset missed keepalive */
 				session->keepalive_misses = 0;
 			}
 		}

--- a/src/common/rohc_tunnel.c
+++ b/src/common/rohc_tunnel.c
@@ -800,6 +800,9 @@ error:
 	tunnel_trace(session, LOG_INFO, "end of thread");
 	session->status = IPROHC_SESSION_PENDING_DELETE;
 	AO_store_release_write(&(session->is_thread_running), 0);
+	/* Parent thread is not calling pthread_join,
+	   so detach thread to free allocated resources */
+	pthread_detach(session->thread_tunnel);
 	return NULL;
 }
 

--- a/src/common/rohc_tunnel.h
+++ b/src/common/rohc_tunnel.h
@@ -29,6 +29,12 @@ along with iprohc.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <gnutls/gnutls.h>
 
+/* Configure GnuTLS and libgcrypt for use in multi-threaded environment */
+#include <gcrypt.h>
+#include <errno.h>
+GCRY_THREAD_OPTION_PTHREAD_IMPL;
+
+
 #include <rohc/rohc.h>
 #include <rohc/rohc_comp.h>
 #include <rohc/rohc_decomp.h>

--- a/src/common/session.c
+++ b/src/common/session.c
@@ -93,7 +93,7 @@ bool iprohc_session_new(struct iprohc_session *const session,
 	session->stop_ctrl = stop_ctrl;
 	session->handle_ctrl_opaque = handle_ctrl_opaque;
 	session->local_address = local_addr;
-	session->src_addr.s_addr = INADDR_ANY;
+	session->src_addr.s_addr = ntohl(local_addr.s_addr);
 	session->dst_addr = remote_addr.sin_addr;
 	session->status = IPROHC_SESSION_CONNECTING;
 	session->thread_tunnel = -1;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -389,6 +389,9 @@ int main(int argc, char *argv[])
 	 * GnuTLS stuff
 	 */
 
+	/* Configure libgcrypt backend for use in multi-threaded environment */
+	gcry_control (GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
+
 	trace(LOG_INFO, "[main] load server certificate from file '%s'",
 			server_opts.pkcs12_f);
 	gnutls_global_init();


### PR DESCRIPTION
Push Viveris' internal Git repository to GitHub :
- Fix KeepAlive issue
- Fix Duplicated packets issue
- Fix use of libgcrypt in multi-threaded environment.
- Fix memory leak on thread ending
